### PR TITLE
Fix play card desync

### DIFF
--- a/src/backend-types/index.ts
+++ b/src/backend-types/index.ts
@@ -45,7 +45,10 @@ image_back_url: string, };
  */
 export type AssetPowerup = "At the end of the game, for one color, turn - into 0 or 0 into +" | "At the end of the game, turn silver into gold on one asset card" | "At the end of the game, count one of your assets as any color";
 
-export type BankerTargetSelectError = "AssetValueToLow" | "AssetAlreadySelected" | "AssetNotSelected" | "InvalidAssetId" | { "InvalidLiabilityId": number } | "LiabilityNotSelected" | "LiabilityAlreadySelected" | "NotCFO" | "AlreadySelected3Liabilities";
+/**
+ * Errors related to selecting assets or liabilities when paying off the banker.
+ */
+export type BankerTargetSelectError = "AssetValueToLow" | "AssetAlreadySelected" | "AssetNotSelected" | { "InvalidAssetId": number } | { "InvalidLiabilityId": number } | "LiabilityNotSelected" | "LiabilityAlreadySelected" | "NotCFO" | "AlreadySelected3Liabilities";
 
 /**
  * A card type used in relation to actions taken with player's hands. Can either be `Asset` or
@@ -117,9 +120,37 @@ character: CharacterType, } } | { "action": "YouTerminateCreditCharacter", "data
  */
 character: CharacterType, } } | { "action": "YouPaidBanker", "data": { 
 /**
- * The amount of gold paid
+ * The id of the player who is the banker.
  */
-banker_id: PlayerId, new_banker_cash: number, your_new_cash: number, paid_amount: number, sold_assets: Array<SoldAssetToPayBanker>, issued_liabilities: Array<IssuedLiabilityToPayBanker>, } } | { "action": "YouSelectCardBankerTarget", "data": { assets: Array<SoldAssetToPayBanker>, liabilities: Array<IssuedLiabilityToPayBanker>, } } | { "action": "YouRegulatorOptions", "data": { 
+banker_id: PlayerId, 
+/**
+ * The new cash balance of the banker.
+ */
+new_banker_cash: number, 
+/**
+ * The new cash balance of the player that was targeted by the banker.
+ */
+your_new_cash: number, 
+/**
+ * The amount of gold paid.
+ */
+paid_amount: number, 
+/**
+ * A list of assets to be sold to pay off the banker.
+ */
+sold_assets: Array<SoldAssetToPayBanker>, 
+/**
+ * A list of liabilities to be issued to pay off the banker.
+ */
+issued_liabilities: Array<IssuedLiabilityToPayBanker>, } } | { "action": "YouSelectCardBankerTarget", "data": { 
+/**
+ * A list of assets to be sold to pay off the banker.
+ */
+assets: Array<SoldAssetToPayBanker>, 
+/**
+ * A list of liabilities to be issued to pay off the banker.
+ */
+liabilities: Array<IssuedLiabilityToPayBanker>, } } | { "action": "YouRegulatorOptions", "data": { 
 /**
  * The options this player has to swap with other players.
  */
@@ -139,7 +170,11 @@ cards_to_draw: number, } } | { "action": "YouSwapPlayer", "data": {
 /**
  * The new hand of the player.
  */
-new_cards: Array<EitherAssetLiability>, } } | { "action": "YouAreDivesting", "data": { 
+new_cards: Array<EitherAssetLiability>, 
+/**
+ * The id of the player you swapped cards with
+ */
+target_player_id: PlayerId, } } | { "action": "YouAreDivesting", "data": { 
 /**
  * A list of cards for each player, which can either be or not be divested.
  */
@@ -183,7 +218,11 @@ character: CharacterType,
 /**
  * A string containing information about what this player is allowed to do.
  */
-perk: string, } } | { "action": "YouBoughtAsset", "data": { 
+perk: string, } } | { "action": "YouBonusCash", "data": { 
+/**
+ * The amount of cash received
+ */
+cash: number, } } | { "action": "YouBoughtAsset", "data": { 
 /**
  * The asset this player bought.
  */
@@ -394,7 +433,7 @@ card_idx: number, } } | { "action": "RedeemLiability", "data": {
 /**
  * The index of the issued liability the player wanst to redeem.
  */
-liability_idx: number, } } | { "action": "UseAbility" } | { "action": "FireCharacter", "data": { 
+liability_idx: number, } } | { "action": "UseAbility" } | { "action": "GetBonusCash" } | { "action": "FireCharacter", "data": { 
 /**
  * The character that is to be fired.
  */
@@ -402,7 +441,24 @@ character: CharacterType, } } | { "action": "TerminateCreditCharacter", "data": 
 /**
  * The character who's credit line will be terminated.
  */
-character: CharacterType, } } | { "action": "SelectAssetToDivest", "data": { asset_id: number, } } | { "action": "UnselectAssetToDivest", "data": { asset_id: number, } } | { "action": "SelectLiabilityToIssue", "data": { liability_id: number, } } | { "action": "UnselectLiabilityToIssue", "data": { liability_id: number, } } | { "action": "PayBanker", "data": { 
+character: CharacterType, } } | { "action": "SelectAssetToDivest", "data": { 
+/**
+ * The index of the asset the player wants to select to pay off the banker.
+ */
+asset_id: number, } } | { "action": "UnselectAssetToDivest", "data": { 
+/**
+ * The index of the asset the player wants to unselect.
+ */
+asset_id: number, } } | { "action": "SelectLiabilityToIssue", "data": { 
+/**
+ * The index of the liability in the player's hand to select to issue to pay off the
+ * banker.
+ */
+liability_id: number, } } | { "action": "UnselectLiabilityToIssue", "data": { 
+/**
+ * The index of the liability in the player's hand the player wants to unselect.
+ */
+liability_id: number, } } | { "action": "PayBanker", "data": { 
 /**
  * The amount of cash to pay
  */
@@ -447,14 +503,32 @@ asset_idx: number, } };
 /**
  * The main error enum used by the game logic.
  */
-export type GameError = { "Lobby": LobbyError } | { "SelectingCharacters": SelectingCharactersError } | { "PlayCard": PlayCardError } | { "RedeemLiability": RedeemLiabilityError } | { "GiveBackCard": GiveBackCardError } | { "DrawCard": DrawCardError } | { "FireCharacter": FireCharacterError } | { "PayBanker": PayBankerError } | { "BankerTargetSelect": BankerTargetSelectError } | { "TerminateCreditCharacter": TerminateCreditCharacterError } | { "Swap": SwapError } | { "DivestAsset": DivestAssetError } | { "CardAbility": AssetAbilityError } | { "InvalidAssetIndex": number } | { "InvalidPlayerCount": number } | { "InvalidPlayerIndex": number } | { "InvalidPlayerName": string } | "PlayerMissingCharacter" | "NotPlayersTurn" | "PlayerShouldGiveBackCard" | "NotLobbyState" | "NotSelectingCharactersState" | "NotRoundState" | "NotBankerTargetState" | "NotResultsState" | "NotAvailableInLobbyState" | "NotAvailableInBankerTargetState" | "NotAvailableInResultsState";
+export type GameError = { "Lobby": LobbyError } | { "SelectingCharacters": SelectingCharactersError } | { "PlayCard": PlayCardError } | { "RedeemLiability": RedeemLiabilityError } | { "GiveBackCard": GiveBackCardError } | { "DrawCard": DrawCardError } | { "FireCharacter": FireCharacterError } | { "PayBanker": PayBankerError } | { "BankerTargetSelect": BankerTargetSelectError } | { "TerminateCreditCharacter": TerminateCreditCharacterError } | { "Swap": SwapError } | { "DivestAsset": DivestAssetError } | { "GetBonusCash": GetBonusCashError } | { "CardAbility": AssetAbilityError } | { "InvalidAssetIndex": number } | { "InvalidPlayerCount": number } | { "InvalidPlayerIndex": number } | { "InvalidPlayerName": string } | "PlayerMissingCharacter" | "NotPlayersTurn" | "PlayerShouldGiveBackCard" | "NotLobbyState" | "NotSelectingCharactersState" | "NotRoundState" | "NotBankerTargetState" | "NotResultsState" | "NotAvailableInLobbyState" | "NotAvailableInBankerTargetState" | "NotAvailableInResultsState";
+
+/**
+ * Errors related to getting bonus gold
+ */
+export type GetBonusCashError = "InvalidCharacter" | "AlreadyGottenBonusCashThisTurn";
 
 /**
  * Errors that can happen when a player must give back a card.
  */
 export type GiveBackCardError = { "InvalidCardIndex": number } | "Unnecessary";
 
-export type IssuedLiabilityToPayBanker = { card_idx: number, liability: LiabilityCard, };
+/**
+ * Struct that represents a liability that a player has selected to be issued to pay off their
+ * obligation to the banker. It contains the index of the liability in the hand of the player, as
+ * well as the liability itself.
+ */
+export type IssuedLiabilityToPayBanker = { 
+/**
+ * The index of the liability in the hand of the player.
+ */
+card_idx: number, 
+/**
+ * The liability to be issued to pay off the banker.
+ */
+liability: LiabilityCard, };
 
 /**
  * Representation of a liability card. Each liability has an associated gold value as well as a
@@ -693,7 +767,19 @@ gold_value: number,
  */
 silver_value: number, };
 
-export type SoldAssetToPayBanker = { asset_idx: number, market_value: number, };
+/**
+ * Structure that represents an asset that is set to be sold to pay off their obligation to the
+ * banker. It contains the index of the asset as well as the market value of the asset.
+ */
+export type SoldAssetToPayBanker = { 
+/**
+ * The index of the asset that can be sold to the banker.
+ */
+asset_idx: number, 
+/**
+ * The market value of the asset that can be sold to the banker.
+ */
+market_value: number, };
 
 /**
  * Errors related to swapping hands/cards.
@@ -803,17 +889,25 @@ player_character: CharacterType,
  */
 skipped_characters: Array<CharacterType>, } } | { "action": "PlayerTargetedByBanker", "data": { 
 /**
- * Id of the player whose turn it is
+ * Id of the player whose turn it is.
  */
 player_turn: PlayerId, 
 /**
- * Amount of Cash to be paid to Banker
+ * Amount of cash to be paid to banker.
  */
 cash_to_be_paid: number, 
 /**
- * Amount of Cash to be paid to Banker
+ * Amount of cash to be paid to banker.
  */
-is_possible_to_pay_banker: boolean, } } | { "action": "SelectedCardsBankerTarget", "data": { assets: Array<SoldAssetToPayBanker>, liability_count: number, } } | { "action": "DrewCard", "data": { 
+is_possible_to_pay_banker: boolean, } } | { "action": "SelectedCardsBankerTarget", "data": { 
+/**
+ * A list of assets to be sold to pay off the banker.
+ */
+assets: Array<SoldAssetToPayBanker>, 
+/**
+ * The number of liabilities the player is set to issue to pay off the banker.
+ */
+liability_count: number, } } | { "action": "DrewCard", "data": { 
 /**
  * The id of the player who drew a card.
  */
@@ -866,7 +960,15 @@ player_id: PlayerId,
 /**
  * The index of the liability this player redeemed.
  */
-liability_idx: number, } } | { "action": "ShareholderIsFiring", "data": Record<string, never> } | { "action": "FiredCharacter", "data": { 
+liability_idx: number, } } | { "action": "PlayerGotBonusCash", "data": { 
+/**
+ * PlayerId of the player who got the bonus gold.
+ */
+player_id: PlayerId, 
+/**
+ * Amount of gold the player receiced.
+ */
+cash: number, } } | { "action": "ShareholderIsFiring", "data": Record<string, never> } | { "action": "FiredCharacter", "data": { 
 /**
  * The id of the player who fired someone.
  */
@@ -882,7 +984,35 @@ player_id: PlayerId,
 /**
  * The character who's credit line was terminated.
  */
-character: CharacterType, } } | { "action": "PlayerPaidBanker", "data": { banker_id: PlayerId, player_id: PlayerId, new_banker_cash: number, new_target_cash: number, paid_amount: number, sold_assets: Array<SoldAssetToPayBanker>, issued_liabilities: Array<IssuedLiabilityToPayBanker>, } } | { "action": "RegulatorSwappedYourCards", "data": { 
+character: CharacterType, } } | { "action": "PlayerPaidBanker", "data": { 
+/**
+ * The id of the player who is the banker this round.
+ */
+banker_id: PlayerId, 
+/**
+ * The id of the player who is the banker.
+ */
+player_id: PlayerId, 
+/**
+ * The new cash balance of the banker.
+ */
+new_banker_cash: number, 
+/**
+ * The new cash balance of the player that was targeted by the banker.
+ */
+new_target_cash: number, 
+/**
+ * The amount of gold paid.
+ */
+paid_amount: number, 
+/**
+ * A list of assets to be sold to pay off the banker.
+ */
+sold_assets: Array<SoldAssetToPayBanker>, 
+/**
+ * A list of liabilities to be issued to pay off the banker.
+ */
+issued_liabilities: Array<IssuedLiabilityToPayBanker>, } } | { "action": "RegulatorSwappedYourCards", "data": { 
 /**
  * This player's new hand.
  */

--- a/src/backend-types/index.ts
+++ b/src/backend-types/index.ts
@@ -189,13 +189,21 @@ perk: string, } } | { "action": "YouBoughtAsset", "data": {
  */
 asset: AssetCard, 
 /**
+ * The index of the asset in the player's hand this player bought.
+ */
+card_idx: number, 
+/**
  * If the market changed, a list of events and a new market is returned.
  */
 market_change: MarketChange | null, } } | { "action": "YouIssuedLiability", "data": { 
 /**
  * The liability the player issued.
  */
-liability: LiabilityCard, } } | { "action": "YouAreFiringSomeone", "data": { 
+liability: LiabilityCard, 
+/**
+ * The index of the liability in the player's hand this player issued.
+ */
+card_idx: number, } } | { "action": "YouAreFiringSomeone", "data": { 
 /**
  * The list of available characters to fire.
  */
@@ -831,6 +839,10 @@ player_id: PlayerId,
  */
 asset: AssetCard, 
 /**
+ * The index of the asset in the player's hand that the player bought.
+ */
+card_idx: number, 
+/**
  * If buying the asset changed the market, sends a list of events as well as the new
  * market.
  */
@@ -842,7 +854,11 @@ player_id: PlayerId,
 /**
  * The liability this player issued.
  */
-liability: LiabilityCard, } } | { "action": "RedeemedLiability", "data": { 
+liability: LiabilityCard, 
+/**
+ * The index of the liability in the player's hand that the player issued.
+ */
+card_idx: number, } } | { "action": "RedeemedLiability", "data": { 
 /**
  * The id of the player who
  */

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,7 +18,7 @@ import NetworkManager from "./models/NetworkManager.js";
 
     const gameState = new GameState();
     const uiManager = new UIManager(app);
-    const networkManager = new NetworkManager(' http://localhost:3000/websocket'); //192.168.67.151
+    const networkManager = new NetworkManager(' http://localhost:3000/websocket'); // http://autobackend.germanywestcentral.azurecontainer.io:3000/webocket
     const gameManager = new GameManager(gameState, uiManager, networkManager);
 
     networkManager.setGameManager(gameManager);

--- a/src/models/GameManager/ServerEventManager.ts
+++ b/src/models/GameManager/ServerEventManager.ts
@@ -407,11 +407,9 @@ class ServerEventManager {
         const player = this.gameState.getLocalPlayer();
         if (!player) return;
 
-        const card = player.hand.filter(c => c instanceof Asset).find(c => c.title === data.asset.title && c.gold === data.asset.gold_value && c.silver === data.asset.silver_value);
-        if (!card) return;
+        const card = player.hand.at(data.card_idx);
+        if (!card || card instanceof Liability) return; // TODO: handle desync. Should not happen
 
-        const cardIndex = player.hand.indexOf(card);
-        if (cardIndex === -1) return;
         if (data.market_change) {
             this.uiManager.hudManager.showMarket(data.market_change.new_market, this.uiManager.marketContainer);
         }
@@ -420,7 +418,7 @@ class ServerEventManager {
         player.gold += card.gold;
         player.silver += card.silver;
         player.assetList.push(card);
-        player.hand.splice(cardIndex, 1);
+        player.hand.splice(data.card_idx, 1);
         player.playableAssets--;
 
         player.positionCardsInHand();
@@ -468,15 +466,12 @@ class ServerEventManager {
         const player = this.gameState.getLocalPlayer();
         if (!player) return;
 
-        const card = player.hand.filter(c => c instanceof Liability).find(c => c.title === data.liability.rfr_type && c.gold === data.liability.value);
-        if (!card) return;
-
-        const cardIndex = player.hand.indexOf(card);
-        if (cardIndex === -1) return;
+        const card = player.hand.at(data.card_idx);
+        if (!card || card instanceof Asset) return; // TODO: handle desync. Should not happen tho
 
         player.cash += card.gold;
         player.liabilityList.push(card);
-        player.hand.splice(cardIndex, 1);
+        player.hand.splice(data.card_idx, 1);
         player.playableLiabilities--;
 
         player.positionCardsInHand();

--- a/src/models/GameManager/ServerEventManager.ts
+++ b/src/models/GameManager/ServerEventManager.ts
@@ -2,7 +2,7 @@ import { Container, Graphics, Text, TextStyle, Ticker, type Application } from '
 import type GameState from '../GameState.js';
 import type UIManager from '../UIManager.js';
 import type NetworkManager from '../NetworkManager.js';
-import type { DirectResponse, UniqueResponse } from '@shared-types';
+import type { CardType, DirectResponse, UniqueResponse } from '@shared-types';
 import Character from '../Characters.js';
 import Player from '../Player.js';
 import Asset from '../Asset.js';
@@ -589,6 +589,7 @@ class ServerEventManager {
                 targetPlayer, 
                 data.cash_to_be_paid, 
                 localPlayer.playerID === targetPlayer.playerID,
+                data.is_possible_to_pay_banker,
                 (amount) => this.networkManager.sendCommand("PayBanker", {cash: amount}),
                 (index) => this.networkManager.sendCommand("SelectAssetToDivest",{asset_id: index}),
                 (index) => this.networkManager.sendCommand("UnselectAssetToDivest",{asset_id: index}),
@@ -904,10 +905,23 @@ class ServerEventManager {
             this.gameManager.activePopup.destroy({ children: true });
             this.gameManager.activePopup = null;
         }
-
+        const localPlayer = this.gameState.getLocalPlayer();
+        const effecterdPlayerID = data.target_player_id;
+        const effecterPlayer= this.gameState.getPlayerById(effecterdPlayerID);
+        let hand: CardType[] = [];
+        localPlayer.hand.forEach(card => {
+            if (card instanceof Asset){
+                hand.push("Asset")
+            }
+            else if(card instanceof Liability){
+                hand.push("Liability")
+            }
+            
+        });
+        effecterPlayer!.othersHand = hand;
         await this.gameManager._updateHandFromServer(data.new_cards);
         
-        const localPlayer = this.gameState.getLocalPlayer();
+        
         this.uiManager.popUpManager.displayYouSwappedNotification(localPlayer);
 
         this.gameManager.switchToMainPhase();

--- a/src/models/GameManager/ServerEventManager.ts
+++ b/src/models/GameManager/ServerEventManager.ts
@@ -287,7 +287,7 @@ class ServerEventManager {
 
         const chairmanPlayer = this.gameState.getPlayerById(data.chairman_id)!;
         //`${localPlayer.name} is choosing their character`;
-        chairmanPlayer.isChaiman = true;
+        
         console.log("Received selectable characters:", data);
 
         this.gameState.openCharacters = this.gameState.characters.filter(character =>

--- a/src/models/Player.ts
+++ b/src/models/Player.ts
@@ -17,7 +17,7 @@ class Player {
     playableLiabilities = 1;
     character: Character | null = null;
     othersHand: CardType[] = [];
-    isChaiman = false;
+   
 
     assetList: Asset[] = [];
     cash = 0;
@@ -164,7 +164,7 @@ class Player {
     resetForNewRound(){
         this.character = null;
         this.reveal = false;
-        this.isChaiman = false;
+        
         this.playableAssets = 1;
         this.playableLiabilities = 1;
         this.maxTempCards = 3;

--- a/src/models/UIManager/PopUpManager.ts
+++ b/src/models/UIManager/PopUpManager.ts
@@ -376,7 +376,7 @@ class PopUpManager {
         this.popupContainer.addChild(tempContainer);
     }
 
-    async playerTargetedByBanker(targetPlayer: Player, cashDue: number, isSelf: boolean, onPayCallback: (amount: number) => void, onSelectCallback: (index: number) => void, onUnelectCallback: (index: number) => void,onSelectLiablityCallback: (index: number) => void,onUnselectLiablityCallback: (index: number) => void ) {
+    async playerTargetedByBanker(targetPlayer: Player, cashDue: number, isSelf: boolean,isPossbilrToPayBanker: boolean, onPayCallback: (amount: number) => void, onSelectCallback: (index: number) => void, onUnelectCallback: (index: number) => void,onSelectLiablityCallback: (index: number) => void,onUnselectLiablityCallback: (index: number) => void ) {
         const tempContainer = this._createPopupBase();
         const x = this.app.screen.width / 2;
         let y = this.app.screen.height / 2 - 300;
@@ -785,7 +785,7 @@ class PopUpManager {
             height: 60,
             onPress: () => {
                 if (tempContainer.parent) tempContainer.parent.removeChild(tempContainer);
-                this.playerTargetedByBanker(targetPlayer, cashDue, true, onPayCallback, onSelectCallback, onUnselectCallback,onSelectLiablityCallback,onUnselectLiablityCallback,);
+                this.playerTargetedByBanker(targetPlayer, cashDue, true,true, onPayCallback, onSelectCallback, onUnselectCallback,onSelectLiablityCallback,onUnselectLiablityCallback,);
             }
         });
         backButton.view.position.set(this.app.screen.width / 2 - (backButton.view.width / 2), this.app.screen.height - 100);
@@ -947,7 +947,7 @@ class PopUpManager {
             height: 60,
             onPress: () => {
                 if (tempContainer.parent) tempContainer.parent.removeChild(tempContainer);
-                this.playerTargetedByBanker(targetPlayer, cashDue, true, onPayCallback, onSelectCallback, onUnselectCallback, onSelectLiablityCallback, onUnselectLiablityCallback);
+                this.playerTargetedByBanker(targetPlayer, cashDue, true,true, onPayCallback, onSelectCallback, onUnselectCallback, onSelectLiablityCallback, onUnselectLiablityCallback);
             }
         });
         backButton.view.position.set(this.app.screen.width / 2 - (backButton.view.width / 2), this.app.screen.height - 100);


### PR DESCRIPTION
Currently the frontend plays a card at an index and only gets back the card. It then tries to figure out what asset or liability is implied based on the title and the gold value and so on which breaks if someone has duplicate cards.

In the spirit of our retrospective today, you can look at this code, comment on it or merge it if you think it looks okay.

Still to do:
- [ ] handle desync. Maybe just console log? No way to currently recover
- [ ] possibly use card idx in the anonymous `BoughtAsset` and `IssuedLiability`. The current implementation actually seems sufficient and actually prevents desyncs